### PR TITLE
gap vs padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
     .nav-link{
       color: #000;
       opacity: 0.8;
+      padding: 0 17px;
     }
 
     .nav-link:hover {
@@ -51,7 +52,6 @@
     .nav-list {
       display:flex;
       float: right;
-      gap: 35px;
       align-items:center;
     }
 


### PR DESCRIPTION
gap didn't work on safari with iPhone 6/7/8 Plus. 
Switching to padding.